### PR TITLE
Avoid deprecation notice about Auto-registration of the command and Use PSR-4

### DIFF
--- a/Command/LevenshteinInstallCommand.php
+++ b/Command/LevenshteinInstallCommand.php
@@ -31,11 +31,13 @@ use Jrk\LevenshteinBundle\ORM\Doctrine\DQL\LevenshteinFunction;
 
 class LevenshteinInstallCommand extends ContainerAwareCommand
 {
- 
+     /** @var string $defaultName */
+    protected static $defaultName = 'jrk:levenshtein:install'; // Make command lazy load
+
     protected function configure()
     {
         $this
-            ->setName('jrk:levenshtein:install')
+            ->setName(self::$defaultName)
             ->setDescription('Create LEVENSHTEIN() and LEVENSHTEIN_RATIO() functions in mysql.')
             ->setDefinition(array())
             ->setHelp(<<<EOT

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,3 +4,7 @@ services:
     jrk_levenshtein.leven_manager:
         class: Jrk\LevenshteinBundle\Manager\LevenshteinManager
         arguments: ["@doctrine.orm.entity_manager"]
+
+    Jrk\LevenshteinBundle\Command\LevenshteinInstallCommand:
+        tags:
+            - { name: 'console.command', command: 'jrk:levenshtein:install' }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "doctrine/dbal": "*"
     },
     "autoload": {
-        "psr-0": { "Jrk\\LevenshteinBundle": "" }
-    },
-    "target-dir": "Jrk/LevenshteinBundle"
+        "psr-4": {
+            "Jrk\\LevenshteinBundle\\": ""
+        }
+    }
 }


### PR DESCRIPTION
This PR removes the deprecation notices about the Auto-registration of the commands in Symfony 4.0 and make composer use PSR-4.